### PR TITLE
Ignore empty projects

### DIFF
--- a/migrate.sh
+++ b/migrate.sh
@@ -549,7 +549,7 @@ function migrateALL(){
 		fi
 
 		# Count number of repos in the project
-		NUMSLUGS=$(echo "$SLUG" | wc -l | tr -d '\040\011\012\015')
+		[[ -z "$SLUG" ]] && NUMSLUGS="0" || NUMSLUGS=$(echo "$SLUG" | wc -l | tr -d '\040\011\012\015')
 		if $DEBUGMODE; then
 			echo "NumSlugs:" "$NUMSLUGS"
 		fi


### PR DESCRIPTION
The command to count the number of slugs returns "1" when the project is empty.
So, when the script tries to pull the repo, a git fatal error happens since `THISSLUG` is a empty string.

```
fatal: not a git repository (or any of the parent directories): .git
```